### PR TITLE
Remove the Packages.app

### DIFF
--- a/buildspec.json
+++ b/buildspec.json
@@ -32,12 +32,6 @@
         }
     },
     "tools": {
-        "packages": {
-            "version": "1.2.10",
-            "baseUrl": "http://s.sudre.free.fr/Software/files",
-            "label": "Packages.app",
-            "hash": "6afdd25386295974dad8f078b8f1e41cabebd08e72d970bf92f707c7e48b16c9"
-        }
     },
     "platformConfig": {
         "macos": {


### PR DESCRIPTION
We no longer use the Packages.app to create pkg on Mac.
The hash of Packages.app is changed and it causes the build failure so that I want to remove the Packages.app.