### PR TITLE
Fix OpenCV binary URL

### DIFF
--- a/cmake/FetchOpenCV.cmake
+++ b/cmake/FetchOpenCV.cmake
@@ -20,7 +20,7 @@ endif()
 
 if(USE_PREDEFINED_OPENCV)
   set(OpenCV_VERSION "4.8.0-1")
-  set(OpenCV_BASEURL "https://github.com/umireon/obs-backgroundremoval-dep-opencv/releases/download/${OpenCV_VERSION}")
+  set(OpenCV_BASEURL "https://github.com/obs-ai/obs-backgroundremoval-dep-opencv/releases/download/${OpenCV_VERSION}")
 
   if(${CMAKE_BUILD_TYPE} STREQUAL Release OR ${CMAKE_BUILD_TYPE} STREQUAL RelWithDebInfo)
     set(OpenCV_BUILD_TYPE Release)


### PR DESCRIPTION
Since we moved the OpenCV repository, we need to fix the URL of it.