### PR TITLE
Update BUILDING-FEDORA.md

### DIFF
--- a/docs/BUILDING-FEDORA.md
+++ b/docs/BUILDING-FEDORA.md
@@ -13,7 +13,7 @@ sudo dnf install cmake gcc-c++ ninja-build obs-studio-devel opencv-devel qt6-qtb
 
 Clone the repository and set up the submodules:
 ```
-git clone https://github.com/royshil/obs-backgroundremoval.git
+git clone https://github.com/obs-ai/obs-backgroundremoval.git --depth=1
 cd obs-backgroundremoval
 git submodule update --init
 ```

--- a/docs/BUILDING-FEDORA.md
+++ b/docs/BUILDING-FEDORA.md
@@ -13,7 +13,7 @@ sudo dnf install cmake gcc-c++ ninja-build obs-studio-devel opencv-devel qt6-qtb
 
 Clone the repository and set up the submodules:
 ```
-git clone https://github.com/obs-ai/obs-backgroundremoval.git --depth=1
+git clone https://github.com/obs-ai/obs-backgroundremoval.git
 cd obs-backgroundremoval
 git submodule update --init
 ```


### PR DESCRIPTION
update url to new org, use shallow clone, save x3 clone time and size


```
$ time git clone https://github.com/royshil/obs-backgroundremoval.git
Cloning into 'obs-backgroundremoval'...
remote: Enumerating objects: 2081, done.
remote: Counting objects: 100% (1204/1204), done.
remote: Compressing objects: 100% (669/669), done.
remote: Total 2081 (delta 750), reused 847 (delta 521), pack-reused 877
Receiving objects: 100% (2081/2081), 56.39 MiB | 1.85 MiB/s, done.
Resolving deltas: 100% (1119/1119), done.

real	0m31.949s
user	0m2.081s
sys	0m1.675s

```

vs
```
$ time git clone https://github.com/royshil/obs-backgroundremoval.git --depth=1
Cloning into 'obs-backgroundremoval'...
remote: Enumerating objects: 257, done.
remote: Counting objects: 100% (257/257), done.
remote: Compressing objects: 100% (219/219), done.
remote: Total 257 (delta 25), reused 152 (delta 21), pack-reused 0
Receiving objects: 100% (257/257), 24.17 MiB | 2.33 MiB/s, done.
Resolving deltas: 100% (25/25), done.

real	0m11.341s
user	0m0.779s
sys	0m0.669s
```